### PR TITLE
reject request if invalid webapk response

### DIFF
--- a/lib/platform.js
+++ b/lib/platform.js
@@ -189,8 +189,16 @@ function Platform(packageName, platforms) {
         headers: headers,
         body: bytes
       })
-      .then(response =>
-        response.arrayBuffer())
+      .then(response => {
+        const status = response.status;
+        const body = response.arrayBuffer();
+        if (status >= 200 && status < 300) {
+          return body;
+        } else {
+          console.error("Error:", response.statusText);
+          return body.then(Promise.reject.bind(Promise));
+        }
+      })
       .then(response => {
           var bytes = new Uint8Array(response);
           var res = webapk.WebApkResponse.deserializeBinary(bytes).array;


### PR DESCRIPTION
Reject request if the webapk server returns an error, so user does not download an invalid webapk.